### PR TITLE
Remove support for chinese numerals 🔻

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.32"
-chinese-number = "0.6.0"
 chrono = { version = "0.4.15", default-features = false }
 lazy_static = "1.4.0"
 numerals = "0.1.4"

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,7 +6,6 @@ use std::ops::Range;
 use std::str::FromStr;
 
 use anyhow::anyhow;
-use chinese_number::{ChineseNumberCountMethod, ChineseNumberToNumber};
 use chrono::{Datelike, NaiveDate, NaiveTime};
 use lazy_static::lazy_static;
 use numerals::roman::Roman;
@@ -1101,8 +1100,6 @@ fn parse_integers(source: &[Chunk]) -> anyhow::Result<i64> {
         Ok(n)
     } else if let Some(roman) = Roman::parse(s) {
         Ok(roman.value() as i64)
-    } else if let Ok(n) = s.parse_chinese_number(ChineseNumberCountMethod::TenThousand) {
-        Ok(n)
     } else {
         Err(anyhow!("Could not parse integer"))
     }


### PR DESCRIPTION
Having support for this adds two (transitive) dependencies and increases binary size by ~50KB. Since it's not even supported by biber, we probably don't need it.