### PR TITLE
serde support added

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ paste = "1"
 regex = { version = "1.4", default-features = false, features = ["std", "unicode-perl"] }
 strum = { version = "0.23", features = ["derive"] }
 unicode-normalization = "0.1"
+serde = { version = "1.0.133", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,5 @@ paste = "1"
 regex = { version = "1.4", default-features = false, features = ["std", "unicode-perl"] }
 strum = { version = "0.23", features = ["derive"] }
 unicode-normalization = "0.1"
-serde = { version = "1.0.133", features = ["derive"] }
+serde = { version = "1.0.133", features = ["derive"], optional = true }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ paste = "1"
 regex = { version = "1.4", default-features = false, features = ["std", "unicode-perl"] }
 strum = { version = "0.23", features = ["derive"] }
 unicode-normalization = "0.1"
-serde = { version = "1.0.133", features = ["derive"], optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -1,12 +1,15 @@
 use crate::resolve::is_escapable;
 use crate::types::Type;
+
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// A sequence of chunks.
 pub type Chunks = Vec<Chunk>;
 
 /// Represents one part of a field value.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Chunk {
     /// Normal values within quotes or single braces subject to
     /// capitalization formatting.

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 pub type Chunks = Vec<Chunk>;
 
 /// Represents one part of a field value.
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Chunk {
     /// Normal values within quotes or single braces subject to
     /// capitalization formatting.

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -1,11 +1,12 @@
 use crate::resolve::is_escapable;
 use crate::types::Type;
+use serde::{Deserialize, Serialize};
 
 /// A sequence of chunks.
 pub type Chunks = Vec<Chunk>;
 
 /// Represents one part of a field value.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub enum Chunk {
     /// Normal values within quotes or single braces subject to
     /// capitalization formatting.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,9 +42,8 @@ use paste::paste;
 use serde::{Deserialize, Serialize};
 
 /// A fully parsed bibliography.
-/// 
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Bibliography {
     /// The bibliography entries.
     entries: Vec<Entry>,
@@ -54,8 +53,8 @@ pub struct Bibliography {
 
 /// A bibliography entry containing chunk fields, which can be parsed into more
 /// specific types on demand.
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Entry {
     /// The citation key.
     pub key: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,9 +37,10 @@ use std::io::{self, Write};
 use mechanics::{AuthorMode, PagesChapterMode};
 
 use paste::paste;
+use serde::{Deserialize, Serialize};
 
 /// A fully parsed bibliography.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Bibliography {
     /// The bibliography entries.
     entries: Vec<Entry>,
@@ -49,7 +50,7 @@ pub struct Bibliography {
 
 /// A bibliography entry containing chunk fields, which can be parsed into more
 /// specific types on demand.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct Entry {
     /// The citation key.
     pub key: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,10 +37,14 @@ use std::io::{self, Write};
 use mechanics::{AuthorMode, PagesChapterMode};
 
 use paste::paste;
+
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// A fully parsed bibliography.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+/// 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
 pub struct Bibliography {
     /// The bibliography entries.
     entries: Vec<Entry>,
@@ -50,7 +54,8 @@ pub struct Bibliography {
 
 /// A bibliography entry containing chunk fields, which can be parsed into more
 /// specific types on demand.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Entry {
     /// The citation key.
     pub key: String,

--- a/src/mechanics.rs
+++ b/src/mechanics.rs
@@ -12,9 +12,9 @@ use serde::{Deserialize, Serialize};
 ///
 /// Each type comes with a different set of required and allowable fields that
 /// are taken into consideration in [`Entry::verify`](crate::Entry::verify).
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Eq, PartialEq, Display, EnumString)]
 #[strum(serialize_all = "lowercase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum EntryType {
     // BibTeX
     Article,

--- a/src/mechanics.rs
+++ b/src/mechanics.rs
@@ -4,12 +4,13 @@
 use std::str::FromStr;
 
 use strum::{Display, EnumString};
+use serde::{Deserialize, Serialize};
 
 /// Describes the type of a bibliographical entry.
 ///
 /// Each type comes with a different set of required and allowable fields that
 /// are taken into consideration in [`Entry::verify`](crate::Entry::verify).
-#[derive(Debug, Clone, Eq, PartialEq, Display, EnumString)]
+#[derive(Debug, Clone, Eq, PartialEq, Display, EnumString, Deserialize, Serialize)]
 #[strum(serialize_all = "lowercase")]
 pub enum EntryType {
     // BibTeX

--- a/src/mechanics.rs
+++ b/src/mechanics.rs
@@ -4,13 +4,16 @@
 use std::str::FromStr;
 
 use strum::{Display, EnumString};
+
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Describes the type of a bibliographical entry.
 ///
 /// Each type comes with a different set of required and allowable fields that
 /// are taken into consideration in [`Entry::verify`](crate::Entry::verify).
-#[derive(Debug, Clone, Eq, PartialEq, Display, EnumString, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Eq, PartialEq, Display, EnumString)]
 #[strum(serialize_all = "lowercase")]
 pub enum EntryType {
     // BibTeX


### PR DESCRIPTION
I think it would be good to add support for [serde](https://serde.rs/) this way to user can convert the bib library to other formats more easily (for example store the references into a mongo database or conversion into another reference system)