### PR TITLE
parse_result first implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,11 +75,17 @@ impl Bibliography {
 
     /// Parse a bibliography from a source string.
     pub fn parse(src: &str) -> Option<Self> {
+        Self::from_raw(RawBibliography::parse(src)).ok()
+    }
+
+    /// Same as parse but return a Result instead of an Option. The Err variant contains the key
+    /// of the entry that failed to parse
+    pub fn parse_result(src: &str) -> Result<Self, String> {
         Self::from_raw(RawBibliography::parse(src))
     }
 
     /// Construct a bibliography from a raw bibliography.
-    pub fn from_raw(raw: RawBibliography) -> Option<Self> {
+    pub fn from_raw(raw: RawBibliography) -> Result<Self, String> {
         let mut res = Self::new();
         let abbr = &raw.abbreviations;
 
@@ -97,7 +103,7 @@ impl Bibliography {
                 })
                 .collect::<HashMap<String, Chunks>>();
             if fields.len() != count {
-                return None;
+                return Err(entry.key.to_string());
             }
             res.insert(Entry {
                 key: entry.key.to_string(),
@@ -106,7 +112,7 @@ impl Bibliography {
             });
         }
 
-        Some(res)
+        Ok(res)
     }
 
     /// The number of bibliography entries.
@@ -826,6 +832,31 @@ mod tests {
     use std::fs;
 
     use super::*;
+
+    #[test]
+    fn test_parse_correct_result() {
+        let contents = fs::read_to_string("tests/gral.bib").unwrap();
+        let option_bibliography = Bibliography::parse(&contents).unwrap();
+        let result_bibliography = Bibliography::parse_result(&contents).unwrap();
+        // Both methods should return the same bibliography for correct input files
+        assert_eq!(option_bibliography.entries, result_bibliography.entries);
+    }
+
+    #[test]
+    fn test_parse_incorrect_result() {
+        let contents = fs::read_to_string("tests/incorrect.bib").unwrap();
+
+        // Regular method should return None
+        let option_bibliography = Bibliography::parse(&contents);
+        assert!(option_bibliography.is_none());
+
+        // Result method should return the key of the incorrect entry
+        let result_bibliography = Bibliography::parse_result(&contents);
+        match result_bibliography {
+            Ok(_) => panic!("Should return Err"),
+            Err(s) => assert_eq!(s, String::from("conigliocorbalan")),
+        };
+    }
 
     #[test]
     fn test_gral_paper() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,13 +74,9 @@ impl Bibliography {
     }
 
     /// Parse a bibliography from a source string.
-    pub fn parse(src: &str) -> Option<Self> {
-        Self::from_raw(RawBibliography::parse(src)).ok()
-    }
-
-    /// Same as parse but return a Result instead of an Option. The Err variant contains the key
-    /// of the entry that failed to parse
-    pub fn parse_result(src: &str) -> Result<Self, String> {
+    ///
+    /// The Err variant contains the key of the entry that failed to parse
+    pub fn parse(src: &str) -> Result<Self, String> {
         Self::from_raw(RawBibliography::parse(src))
     }
 
@@ -836,23 +832,17 @@ mod tests {
     #[test]
     fn test_parse_correct_result() {
         let contents = fs::read_to_string("tests/gral.bib").unwrap();
-        let option_bibliography = Bibliography::parse(&contents).unwrap();
-        let result_bibliography = Bibliography::parse_result(&contents).unwrap();
-        // Both methods should return the same bibliography for correct input files
-        assert_eq!(option_bibliography.entries, result_bibliography.entries);
+        let bibliography = Bibliography::parse(&contents).unwrap();
+        assert_eq!(bibliography.entries.len(), 85)
     }
 
     #[test]
     fn test_parse_incorrect_result() {
         let contents = fs::read_to_string("tests/incorrect.bib").unwrap();
 
-        // Regular method should return None
-        let option_bibliography = Bibliography::parse(&contents);
-        assert!(option_bibliography.is_none());
-
-        // Result method should return the key of the incorrect entry
-        let result_bibliography = Bibliography::parse_result(&contents);
-        match result_bibliography {
+        // Parse should return the key of the incorrect entry
+        let bibliography = Bibliography::parse(&contents);
+        match bibliography {
             Ok(_) => panic!("Should return Err"),
             Err(s) => assert_eq!(s, String::from("conigliocorbalan")),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,8 +74,6 @@ impl Bibliography {
     }
 
     /// Parse a bibliography from a source string.
-    ///
-    /// The Err variant contains the key of the entry that failed to parse
     pub fn parse(src: &str) -> Result<Self, String> {
         Self::from_raw(RawBibliography::parse(src))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,20 +86,21 @@ impl Bibliography {
         let abbr = &raw.abbreviations;
 
         for entry in raw.entries {
-            let count = entry.fields.len();
-            let fields = entry
-                .fields
-                .into_iter()
-                .filter_map(|(key, value)| {
-                    if let Some(r) = resolve::resolve(value, abbr) {
-                        Some((key.to_string(), r))
-                    } else {
-                        None
-                    }
-                })
-                .collect::<HashMap<String, Chunks>>();
-            if fields.len() != count {
-                return Err(entry.key.to_string());
+            // Check that the key is not repeated
+            if res.get(entry.key).is_some() {
+                return Err(format!("Repeated key '{}'", entry.key));
+            }
+
+            let mut fields = HashMap::new();
+            for (field_key, field_value) in entry.fields.into_iter() {
+                if let Some(r) = resolve::resolve(field_value, abbr) {
+                    fields.insert(field_key.to_string(), r);
+                } else {
+                    return Err(format!(
+                        "Error parsing entry with key '{}', field '{}'",
+                        entry.key, field_key
+                    ));
+                }
             }
             res.insert(Entry {
                 key: entry.key.to_string(),
@@ -830,21 +831,39 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_correct_result() {
+    fn test_correct_bib() {
         let contents = fs::read_to_string("tests/gral.bib").unwrap();
         let bibliography = Bibliography::parse(&contents).unwrap();
-        assert_eq!(bibliography.entries.len(), 85)
+        assert_eq!(bibliography.entries.len(), 83)
+    }
+
+    #[test]
+    fn test_repeated_key() {
+        let contents = fs::read_to_string("tests/gral_rep_key.bib").unwrap();
+        let bibliography = Bibliography::parse(&contents);
+        match bibliography {
+            Ok(_) => panic!("Should return Err"),
+            Err(s) => {
+                assert_eq!(s, String::from("Repeated key 'ishihara2012'"));
+            },
+        };
     }
 
     #[test]
     fn test_parse_incorrect_result() {
         let contents = fs::read_to_string("tests/incorrect.bib").unwrap();
 
-        // Parse should return the key of the incorrect entry
         let bibliography = Bibliography::parse(&contents);
         match bibliography {
             Ok(_) => panic!("Should return Err"),
-            Err(s) => assert_eq!(s, String::from("conigliocorbalan")),
+            Err(s) => {
+                assert_eq!(
+                    s,
+                    String::from(
+                        "Error parsing entry with key 'conigliocorbalan', field 'author'"
+                    )
+                );
+            },
         };
     }
 

--- a/tests/gral_rep_key.bib
+++ b/tests/gral_rep_key.bib
@@ -1,3 +1,6 @@
+% Identical to gral.bib but the key ishihara2012 is repeated
+% (it appears first as an article and then as inproceedings)
+
 @article{rashid2016,
   title={Applications of wireless sensor networks for urban areas: A survey},
   author={Rashid, Bushra and Rehmani, Mubashir Husain},
@@ -795,6 +798,14 @@ volume = {9},
 number = {2},
 year = {2018},
 abstract = {Sensor networks have gained tremendous appreciation in recent years and have been successfully tested in various application scenarios such as disaster management, pipeline monitoring, and environmental monitoring, as well as different military and security-based applications. In order to protect pipelines from leakage and corrosion, various conventional methods and techniques are used for monitoring. Functioning only in a specific environment, these conventional techniques require special infrastructure and higher maintenance. These challenges could, however, be overcome efficiently by using wireless sensors and robots. Most previous surveys mainly focused on the hardware design of the sensors, basic sensing techniques, and transmission media, but overlooked conducting an exclusive survey of pipeline monitoring schemes using linearly deployed wireless sensor networks or robots. This study attempts to carry out an extensive survey on the factors affecting pipeline monitoring techniques and provides novel classification in terms of classifying them into different strategies, sensor types, sensing coverage, communication methods, and monitoring types. In addition, a survey of comparative analysis of existing pipeline monitoring techniques is also presented, and general pipeline monitoring methods are also compared and summarized. Moreover, the need to explore pipeline monitoring schemes that incorporate wireless sensor networks (WSNs) is highlighted because WSNs are easy to deploy and flexible enough to be installed in any environment. This study discovers that most existing pipeline monitoring schemes that do not deploy sensors in a linear direction, which ultimately increases the cost and reduces overall network performance. Finally, several unresolved issues occurring in the development of pipeline monitoring techniques are highlighted, and future directions are provided accordingly. }
+}
+
+@inproceedings{ishihara2012,
+  title={Active node selection in flowing wireless sensor networks},
+  author={Ishihara, Susumu and Sato, Daisuke},
+  booktitle={Proceedings of the 6th International Conference on Mobile Computing and Ubiquitous Networking (IMCU)},
+  pages={8--15},
+  year={2012}
 }
 
 @ARTICLE{adedeji2017,

--- a/tests/incorrect.bib
+++ b/tests/incorrect.bib
@@ -8,6 +8,7 @@
   publisher={Elsevier}
 }
 
+% The following entry is incorrect because there is an extra "\" before the i in Mar{\'{\i}}a
 @inproceedings{conigliocorbalan,
   author    = {Marcelo Coniglio and Mar{\'{\i}}a I. Corbal{\'{a}}n},
   title     = {Sequent Calculi for the classical fragment of {B}ochvar and {H}alld{\'{e}}n's {N}onsense {L}ogics},

--- a/tests/incorrect.bib
+++ b/tests/incorrect.bib
@@ -1,0 +1,17 @@
+@article{rashid2016,
+  title={Applications of wireless sensor networks for urban areas: A survey},
+  author={Rashid, Bushra and Rehmani, Mubashir Husain},
+  journal={Journal of network and computer applications},
+  volume={60},
+  pages={192--219},
+  year={2016},
+  publisher={Elsevier}
+}
+
+@inproceedings{conigliocorbalan,
+  author    = {Marcelo Coniglio and Mar{\'{\i}}a I. Corbal{\'{a}}n},
+  title     = {Sequent Calculi for the classical fragment of {B}ochvar and {H}alld{\'{e}}n's {N}onsense {L}ogics},
+  booktitle = {Proceedings Seventh Workshop on Logical and Semantic Frameworks, with Applications, {LSFA} 2012, Rio de Janeiro, Brazil, September 29-30, 2012.},
+  pages     = {125--136},
+  year      = {2012},
+}


### PR DESCRIPTION
Hi, in accordance with the issue I opened, I took the liberty of making this pull request.
It adds a new method (in order to not break any existing code) to `Bibliography`, called `parse_result`, that returns a `Result` instead of an `Option`. The `Err` variant returns a string with the key of the entry that failed to parse.
In the future, there could be a more complete explanation as to why `parse` failed / which fields were incorrect and why, but as a first approximation I think this works. I also added a couple of tests for it.
Feel free to edit, of course (e.g. to modify the version of the package in `Cargo.toml`).