### PR TITLE
Ordered writes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ regex = { version = "1.4", default-features = false, features = ["std", "unicode
 strum = { version = "0.23", features = ["derive"] }
 unicode-normalization = "0.1"
 serde = { version = "1.0", features = ["derive"], optional = true }
-
+itertools = "0.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -563,7 +563,7 @@ impl Entry {
                 // If the key coincides with the nth element of the order vector
                 if x.0 == ord_param {
                     // If order is ["title", "author"], author key will be ordered as "001".
-                    return format!("{:03}{}", idx, ord_param);
+                    return format!("{:03}", idx);
                 }
             }
             // If not in the order vec, order as the key

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1019,6 +1019,20 @@ mod tests {
         let contents = fs::read_to_string("tests/cross.bib").unwrap();
         let mut bibliography = Bibliography::parse(&contents).unwrap();
 
+        // An empty vec means order every field aphabetically
+        let order = vec![];
+        let biblatex = bibliography
+            .get_mut("haug2019")
+            .unwrap()
+            .to_biblatex_string_ordered(&order);
+        assert_eq!(biblatex, "@thesis{haug2019,\n\
+                                 author = {Haug, Martin},\n\
+                                 date = {2019-10},\n\
+                                 institution = {Technische Universität Berlin},\n\
+                                 title = {Batch Localization Algorithm for Floating Wireless Sensor Networks},\n\
+                                 type = {Bachelor's Thesis},\n\
+                               }");
+
         let order1 = vec!["title", "author"];
         let biblatex1 = bibliography
             .get_mut("haug2019")


### PR DESCRIPTION
Something that was also bothering me was that each time you called `to_bibtex_string` or `to_biblatex_string` it generated a different output, because the fields of each entry were being iterated on in random order. So, I made two extra methods that take a vec of &str's specifying the ordering of the fields. For example, if the vec is `vec!["title", "author"]` the functions will place the title and author fields first, and order the rest alphabetically.