### PR TITLE
Don't escape colons when writing verbatim fields

### DIFF
--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -64,7 +64,7 @@ impl Chunk {
     pub fn to_biblatex_string(&self, is_verbatim: bool) -> String {
         let mut s = String::new();
         for c in self.get().chars() {
-            if is_escapable(c, is_verbatim) {
+            if is_escapable(c, is_verbatim, false) {
                 s.push('\\');
             }
             s.push(c);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1185,11 +1185,23 @@ mod tests {
     fn test_verbatim_fields() {
         let contents = fs::read_to_string("tests/libra.bib").unwrap();
         let bibliography = Bibliography::parse(&contents).unwrap();
+
+        // Import an entry/field with escaped colons
         let e = bibliography.get("dierksmeierJustHODLMoral2018").unwrap();
         assert_eq!(e.doi().unwrap(), "10.1007/s41463-018-0036-z");
         assert_eq!(
             e.file().unwrap(),
             "C:\\Users\\mhaug\\Zotero\\storage\\DTPR7TES\\Dierksmeier - 2018 - Just HODL On the Moral Claims of Bitcoin and Ripp.pdf"
         );
+
+        // Import an entry/field with unescaped colons
+        let e = bibliography.get("LibraAssociationIndependent").unwrap();
+        assert_eq!(e.url().unwrap(), "https://libra.org/association/");
+
+        // Test export of entry (not escaping colons)
+        let e = bibliography.get("finextraFedGovernorChallenges2019").unwrap();
+        assert_eq!(e.to_biblatex_string(), 
+        "@online{finextraFedGovernorChallenges2019,\nauthor = {FinExtra},\ndate = {2019-12-18},\nfile = {C:\\\\Users\\\\mhaug\\\\Zotero\\\\storage\\\\VY9LAKFE\\\\fed-governor-challenges-facebooks-libra-project.html},\ntitle = {Fed {Governor} Challenges {Facebook}'s {Libra} Project},\nurl = {https://www.finextra.com/newsarticle/34986/fed-governor-challenges-facebooks-libra-project},\nurldate = {2020-08-22},\n}"
+        )
     }
 }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -136,7 +136,7 @@ impl<'s> ContentParser<'s> {
     fn backslash(&mut self) -> Result<String, ParseError> {
         self.eat_assert('\\');
         match self.s.peek() {
-            Some(c) if is_escapable(c, self.verb_field) => {
+            Some(c) if is_escapable(c, self.verb_field, true) => {
                 self.s.eat();
                 Ok(c.to_string())
             }
@@ -380,10 +380,15 @@ fn flatten(chunks: &mut Chunks) {
 }
 
 /// Characters that can be escaped.
-pub fn is_escapable(c: char, verb: bool) -> bool {
+///
+/// In read mode (`read_char = true`), colons are also converted to an unescaped string to keep
+/// compatiblity with Zotero. Zotero escapes colons when exporting verbatim fields. This crate
+/// doesn't escape colons when exporting.
+pub fn is_escapable(c: char, verb: bool, read_char: bool) -> bool {
     match c {
-        '{' | '}' | '\\' | ':' => true,
+        '{' | '}' | '\\' => true,
         '&' | '%' | '$' | '_' if !verb => true,
+        ':' if read_char => true,
         _ => false,
     }
 }


### PR DESCRIPTION
Hello,

this PR fixes the discussion around colons in #21 .

I'm not sure whether it's smartest way to differentiate between a write and read mode but didn't come up with a better idea so far. Looking forward to your comments!

Best 