### PR TITLE
feat: add support for multiline author field

### DIFF
--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -276,14 +276,13 @@ pub(crate) fn split_token_lists_surrounded_by_whitespace(
     let mut first_chunk = true;
     while let Some(val) = vals.next() {
         if let Chunk::Normal(s) = &val.v {
-            let mut start = val.span.start;
-            let mut cur = String::new();
+            let mut span_start = val.span.start;
 
             // if first chunk is normal -> leading and
             let s = if first_chunk {
                 let new_s = s.trim_start();
                 if !val.is_detached() {
-                    start += s.len() - new_s.len();
+                    span_start = val.span.start + s.len() - new_s.len();
                 }
                 new_s
             } else {
@@ -297,8 +296,10 @@ pub(crate) fn split_token_lists_surrounded_by_whitespace(
                 .map(move |sub| (sub.as_ptr() as usize - s.as_ptr() as usize, sub))
                 .peekable();
 
+            let mut start = 0;
+            let mut cur = String::new();
             if !val.is_detached() {
-                start += splits_with_indexes.peek().unwrap_or(&(0, "")).0;
+                start = span_start + splits_with_indexes.peek().unwrap_or(&(0, "")).0;
             }
 
             while let Some((idx, split)) = splits_with_indexes.next() {
@@ -320,7 +321,7 @@ pub(crate) fn split_token_lists_surrounded_by_whitespace(
                     out.push(std::mem::take(&mut latest));
 
                     if !val.is_detached() {
-                        start += splits_with_indexes.peek().unwrap_or(&(0, "")).0;
+                        start = span_start + splits_with_indexes.peek().unwrap_or(&(0, "")).0;
                     }
 
                     continue;

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -311,9 +311,10 @@ pub(crate) fn split_token_lists_surrounded_by_whitespace(
                     }
                 }
 
-                // if trailing "and" or leading "and" or any of the neighbouring chars are not whitespaces
+                // if trailing keyword or leading keyword or
+                // any of the neighbouring chars are not whitespaces
                 cur += prev;
-                cur += "and";
+                cur += keyword;
                 prev = split;
             }
 

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -190,7 +190,7 @@ impl ChunksExt for [Spanned<Chunk>] {
 }
 
 /// An iterator over the characters in each chunk, indicating whether they are
-/// verbatim or not. Chunk types other than `Normal` or `Verbatim` are ommitted.
+/// verbatim or not. Chunk types other than `Normal` or `Verbatim` are omitted.
 pub(crate) fn chunk_chars(chunks: ChunksRef) -> impl Iterator<Item = (char, bool)> + '_ {
     chunks.iter().flat_map(|chunk| {
         let (s, verbatim) = chunk.v.get_and_verb();
@@ -199,7 +199,7 @@ pub(crate) fn chunk_chars(chunks: ChunksRef) -> impl Iterator<Item = (char, bool
     })
 }
 
-/// Combines the cunks, interlacing with the separator.
+/// Combines the chunks, interlacing with the separator.
 pub(crate) fn join_chunk_list(chunks: ChunksRef, sep: &str) -> Chunks {
     let mut res = vec![];
     let mut first = true;
@@ -221,7 +221,7 @@ pub(crate) fn join_chunk_list(chunks: ChunksRef, sep: &str) -> Chunks {
 }
 
 /// Splits chunk vectors that are a token lists as defined per the
-/// [BibLaTeX Manual][manual] p. 16 along occurances of the keyword.
+/// [BibLaTeX Manual][manual] p. 16 along occurrences of the keyword.
 ///
 /// [manual]: http://ctan.ebinger.cc/tex-archive/macros/latex/contrib/biblatex/doc/biblatex.pdf
 pub(crate) fn split_token_lists(vals: ChunksRef, keyword: &str) -> Vec<Chunks> {
@@ -258,12 +258,12 @@ pub(crate) fn split_token_lists(vals: ChunksRef, keyword: &str) -> Vec<Chunks> {
     out
 }
 
-/// Split the token list based on a keyword surrounded by whitespaces
+/// Split the token list based on a keyword surrounded by whitespace
 ///
 /// For Normal Chunks,
 /// - The leading/trailing keyword is not considered as a valid split
 /// (regardless of whether the keyword is preceded/followed by some
-/// whitespaces).
+/// whitespace).
 /// - If there are consecutive keywords, the characters between two consecutive
 /// keywords (whether only whitespace or not) will be considered as a valid
 /// split.
@@ -317,7 +317,7 @@ pub(crate) fn split_token_lists_with_kw(vals: ChunksRef, keyword: &str) -> Vec<C
             let s = if chunk_idx == vals.len() - 1 { s.trim_end() } else { &s };
 
             let mut splits = s.split(keyword);
-            // guaranteed to have values
+            // guaranteed to have a value
             let mut prev = splits.next().unwrap();
 
             let mut cur = String::new();
@@ -366,7 +366,7 @@ pub(crate) fn split_token_lists_with_kw(vals: ChunksRef, keyword: &str) -> Vec<C
     out
 }
 
-/// Splits a chunk vector into two at the first occurrance of the character `c`.
+/// Splits a chunk vector into two at the first occurrence of the character `c`.
 /// `omit` controls whether the output will contain `c`.
 pub(crate) fn split_at_normal_char(
     src: ChunksRef,
@@ -424,9 +424,9 @@ pub(crate) fn split_values(
 
     let (s1, s2) = content.split_at(str_idx);
 
-    let boundry = item.span.start.saturating_add(str_idx);
-    item.span = item.span.start..boundry;
-    let new_span = boundry..boundry.saturating_add(s2.len());
+    let boundary = item.span.start.saturating_add(str_idx);
+    item.span = item.span.start..boundary;
+    let new_span = boundary..boundary.saturating_add(s2.len());
 
     let s1 = s1.trim_end().to_string();
     let s2 = s2.trim_start().to_string();

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -323,28 +323,23 @@ pub(crate) fn split_token_lists_with_kw(vals: ChunksRef, keyword: &str) -> Vec<C
             let mut cur = String::new();
 
             for split in splits {
-                if let (Some(left_last), Some(right_first)) =
-                    (prev.chars().last(), split.chars().next())
+                if prev.ends_with(char::is_whitespace)
+                    && split.starts_with(char::is_whitespace)
                 {
-                    if left_last.is_whitespace() && right_first.is_whitespace() {
-                        cur += prev;
-                        let end = if chunk.is_detached() {
-                            usize::MAX
-                        } else {
-                            start + cur.len()
-                        };
-                        latest.push(Spanned::new(
-                            Chunk::Normal(std::mem::take(&mut cur)),
-                            start..end,
-                        ));
+                    cur += prev;
+                    let end =
+                        if chunk.is_detached() { usize::MAX } else { start + cur.len() };
+                    latest.push(Spanned::new(
+                        Chunk::Normal(std::mem::take(&mut cur)),
+                        start..end,
+                    ));
 
-                        sanitize_latest(&mut latest);
-                        out.push(std::mem::take(&mut latest));
+                    sanitize_latest(&mut latest);
+                    out.push(std::mem::take(&mut latest));
 
-                        start = end;
-                        prev = split;
-                        continue;
-                    }
+                    start = end;
+                    prev = split;
+                    continue;
                 }
 
                 cur += prev;

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -295,11 +295,12 @@ pub(crate) fn split_token_lists_surrounded_by_whitespace(
 
                         // trim_end
                         cur = cur_trim_start.trim_end().to_string();
+                        let end = start + cur.len();
 
                         // push previous successful split
                         latest.push(Spanned::new(
                             Chunk::Normal(std::mem::take(&mut cur)),
-                            start..start + cur.len(),
+                            start..start + end,
                         ));
                         out.push(std::mem::take(&mut latest));
 

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -272,19 +272,19 @@ pub(crate) fn split_token_lists_surrounded_by_whitespace(
     for val in vals {
         if let Chunk::Normal(s) = &val.v {
             let mut start = val.span.start;
-            let possible_splits: Vec<&str> = s.split(keyword).collect();
+            let mut splits = s.split(keyword);
+            // guaranteed to have values
+            let mut prev = splits.next().unwrap();
 
             let mut cur = String::new();
-            let mut j = 1;
 
-            while j < possible_splits.len() {
-                if let (Some(left_last), Some(right_first)) = (
-                    possible_splits[j - 1].chars().last(),
-                    possible_splits[j].chars().next(),
-                ) {
+            for split in splits {
+                if let (Some(left_last), Some(right_first)) =
+                    (prev.chars().last(), split.chars().next())
+                {
                     if left_last.is_whitespace() && right_first.is_whitespace() {
                         // add remaining value to the cur
-                        cur += possible_splits[j - 1];
+                        cur += prev;
 
                         // trim start and advance start
                         let cur_trim_start = cur.trim_start();
@@ -306,18 +306,18 @@ pub(crate) fn split_token_lists_surrounded_by_whitespace(
 
                         // continue
                         start = new_start;
-                        j += 1;
+                        prev = split;
                         continue;
                     }
                 }
 
                 // if trailing "and" or leading "and" or any of the neighbouring chars are not whitespaces
-                cur += possible_splits[j - 1];
+                cur += prev;
                 cur += "and";
-                j += 1;
+                prev = split;
             }
-            cur += possible_splits[j - 1];
 
+            cur += prev;
             let cur_trim_start = cur.trim_start();
             start += cur.len() - cur_trim_start.len();
             latest.push(Spanned::new(

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -320,10 +320,10 @@ pub(crate) fn split_token_lists_surrounded_by_whitespace(
 
             let cur_trim_start = cur.trim_start();
             start += cur.len() - cur_trim_start.len();
-            cur = cur_trim_start.trim_end().to_string();
-            let end = start + cur.len();
-
-            latest.push(Spanned::new(Chunk::Normal(cur), start..end));
+            latest.push(Spanned::new(
+                Chunk::Normal(cur_trim_start.to_string()),
+                start..val.span.end,
+            ));
         } else {
             latest.push(val.clone());
         }

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -258,10 +258,13 @@ pub(crate) fn split_token_lists(vals: ChunksRef, keyword: &str) -> Vec<Chunks> {
     out
 }
 
-/// Splits chunk vectors that are a token lists as defined per the
-/// [BibLaTeX Manual][manual] p. 16 along occurances of the keyword.
+/// Split the token list based on a keyword surrounded by whitespaces
 ///
-/// [manual]: http://ctan.ebinger.cc/tex-archive/macros/latex/contrib/biblatex/doc/biblatex.pdf
+/// For Normal Chunk,
+/// - The leading/trailing keyword is not considered as a valid split
+/// (regardless of whether the keyword is preceded/after by some whitespaces).
+/// - If there are consecutive keywords, the words between two consecutive keywords
+/// (whether empty or not) will be considered as a valid split.
 pub(crate) fn split_token_lists_surrounded_by_whitespace(
     vals: ChunksRef,
     keyword: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub struct Bibliography {
 pub struct Entry {
     /// The citation key.
     pub key: String,
-    /// Denotes the type of bibliography item (e.g. `Article`).
+    /// Denotes the type of bibliography item (e.g., `Article`).
     pub entry_type: EntryType,
     /// Maps from field names to their associated chunk vectors.
     pub fields: BTreeMap<String, Chunks>,
@@ -311,14 +311,14 @@ impl Entry {
 
     /// Set the chunk slice for a field.
     ///
-    /// The field key is lowercased before insertion.
+    /// The field key is lowercase before insertion.
     pub fn set(&mut self, key: &str, chunks: Chunks) {
         self.fields.insert(key.to_lowercase(), chunks);
     }
 
     /// Set the value of a field as a specific type.
     ///
-    /// The field key is lowercased before insertion.
+    /// The field key is lowercase before insertion.
     pub fn set_as<T: Type>(&mut self, key: &str, value: &T) {
         self.set(key, value.to_chunks());
     }
@@ -582,7 +582,7 @@ impl Entry {
         }
     }
 
-    /// Resolves all data dependancies defined by `crossref` and `xdata` fields.
+    /// Resolves all data dependencies defined by `crossref` and `xdata` fields.
     fn resolve_crossrefs(&mut self, bib: &Bibliography) -> Result<(), TypeError> {
         let mut refs = vec![];
 
@@ -718,7 +718,7 @@ impl Entry {
 
 /// A report of the validity of an `Entry`. Can be obtained by calling [`Entry::verify`].
 pub struct Report {
-    /// These fields were missing although they are required for the entry type.
+    /// These fields were missing, although they are required for the entry type.
     pub missing: Vec<&'static str>,
     /// These fields were present but are not allowed for the entry type.
     pub superfluous: Vec<&'static str>,
@@ -878,7 +878,7 @@ type Span = std::ops::Range<usize>;
 
 /// A value with the span it corresponds to in the source code.
 ///
-/// Spans can be _detatched,_ this means that they deliberately do not point
+/// Spans can be _detached,_ this means that they deliberately do not point
 /// into the source code. Such spans are created when manually setting fields
 /// with an empty bibliography or after parsing a file. Detached spans do not
 /// indicate valid index ranges in the source files and must not be used as

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -26,7 +26,7 @@ pub struct RawBibliography<'s> {
 pub struct RawEntry<'s> {
     /// The citation key.
     pub key: Spanned<&'s str>,
-    /// Denotes the type of bibliographic item (e.g. `article`).
+    /// Denotes the type of bibliographic item (e.g., `article`).
     pub kind: Spanned<&'s str>,
     /// Maps from field names to their values.
     pub fields: Vec<(Spanned<&'s str>, Spanned<Field<'s>>)>,
@@ -471,7 +471,7 @@ impl<'s> BiblatexParser<'s> {
         Ok(())
     }
 
-    /// Eat the body of a entry.
+    /// Eat the body of an entry.
     fn body(&mut self, kind: Spanned<&'s str>, start: usize) -> Result<(), ParseError> {
         let key = self.ident()?;
         self.s.eat_whitespace();

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -278,7 +278,7 @@ fn resolve_abbreviation(
 }
 
 /// Best-effort evaluation of LaTeX commands with a focus on diacritics.
-/// Will dump the command arguments if evaluation not possible.
+/// Will dump the command arguments if evaluation is not possible.
 /// Nested commands are not supported.
 fn execute_command(command: &str, arg: Option<&str>) -> String {
     fn last_char_combine(v: Option<&str>, combine: char) -> String {

--- a/src/types/date.rs
+++ b/src/types/date.rs
@@ -404,12 +404,9 @@ impl Datetime {
         } else {
             // This might be an incomplete date, missing day and possibly month.
             let mut s = Scanner::new(&slice);
-            s.eat_whitespace();
             let year = get_year(&mut s)?;
-            s.eat_whitespace();
 
             let month = if s.eat_while('-').len() > 0 {
-                s.eat_whitespace();
                 let month_start = s.cursor();
                 let month = s.eat_while(char::is_ascii_digit);
                 if month.len() != 2 {

--- a/src/types/date.rs
+++ b/src/types/date.rs
@@ -39,8 +39,8 @@ pub struct Datetime {
     /// The year.
     ///
     /// AD years are counted starting from one and thus represented as exactly
-    /// their year (e.g. 2000 AD is `2000`) whereas BC years are counted
-    /// starting from zero downwards (e.g. 1000 BC is `999`)
+    /// their year (e.g., 2000 AD is `2000`) whereas BC years are counted
+    /// starting from zero downwards (e.g., 1000 BC is `999`)
     pub year: i32,
     /// The month (starting at zero).
     pub month: Option<u8>,

--- a/src/types/date.rs
+++ b/src/types/date.rs
@@ -376,11 +376,14 @@ impl DateValue {
 
 impl Datetime {
     /// Parse a datetime from a string.
-    fn parse(mut src: &str) -> Result<Self, TypeError> {
-        let time = if let Some(pos) = src.find('T') {
-            if pos + 1 < src.len() {
-                let time_str = &src[pos + 1..];
-                src = &src[..pos];
+    fn parse(src: &str) -> Result<Self, TypeError> {
+        let src = src.chars().filter(|c| !c.is_whitespace()).collect::<String>();
+        let mut slice = &src[..];
+
+        let time = if let Some(pos) = slice.find('T') {
+            if pos + 1 < slice.len() {
+                let time_str = &slice[pos + 1..];
+                slice = &slice[..pos];
                 time_str.parse::<NaiveTime>().ok()
             } else {
                 None
@@ -389,7 +392,7 @@ impl Datetime {
             None
         };
 
-        let full_date = src.parse::<NaiveDate>();
+        let full_date = slice.parse::<NaiveDate>();
 
         Ok(if let Ok(ndate) = full_date {
             Datetime {
@@ -400,7 +403,7 @@ impl Datetime {
             }
         } else {
             // This might be an incomplete date, missing day and possibly month.
-            let mut s = Scanner::new(&src);
+            let mut s = Scanner::new(&slice);
             s.eat_whitespace();
             let year = get_year(&mut s)?;
             s.eat_whitespace();

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -150,7 +150,7 @@ impl Type for Range<u32> {
 impl Type for Vec<Chunks> {
     /// Splits the chunks at `"and"`s.
     fn from_chunks(chunks: ChunksRef) -> Result<Self, TypeError> {
-        Ok(split_token_lists_surrounded_by_whitespace(chunks, "and"))
+        Ok(split_token_lists_with_kw(chunks, "and"))
     }
 
     fn to_chunks(&self) -> Chunks {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -150,7 +150,7 @@ impl Type for Range<u32> {
 impl Type for Vec<Chunks> {
     /// Splits the chunks at `"and"`s.
     fn from_chunks(chunks: ChunksRef) -> Result<Self, TypeError> {
-        Ok(split_token_lists(chunks, " and "))
+        Ok(split_token_lists_surrounded_by_whitespace(chunks, "and"))
     }
 
     fn to_chunks(&self) -> Chunks {

--- a/src/types/person.rs
+++ b/src/types/person.rs
@@ -394,7 +394,7 @@ Claude Garamond and",
         let names = String::from(
             "Johannes Gutenberg and and
 Aldus Manutius and
-Claude Garamond and",
+Claude Garamond",
         );
         let range = std::ops::Range { start: 0, end: names.len() };
         let people = &[Spanned::new(Chunk::Normal(names), range)];
@@ -408,7 +408,7 @@ Claude Garamond and",
         let names = String::from(
             "Johannes Gutenberg and and and
 Aldus Manutius and
-Claude Garamond and",
+Claude Garamond",
         );
         let range = std::ops::Range { start: 0, end: names.len() };
         let people = &[Spanned::new(Chunk::Normal(names), range)];

--- a/src/types/person.rs
+++ b/src/types/person.rs
@@ -217,7 +217,7 @@ impl Person {
 
 impl Type for Vec<Person> {
     fn from_chunks(chunks: ChunksRef) -> Result<Self, TypeError> {
-        Ok(split_token_lists_surrounded_by_whitespace(chunks, "and")
+        Ok(split_token_lists_with_kw(chunks, "and")
             .into_iter()
             .map(|subchunks| Person::parse(&subchunks))
             .collect())

--- a/src/types/person.rs
+++ b/src/types/person.rs
@@ -286,8 +286,7 @@ mod tests {
     fn test_list_of_names() {
         let names =
             String::from("Johannes Gutenberg and Aldus Manutius and Claude Garamond");
-        let range = std::ops::Range { start: 0, end: names.len() };
-        let people = &[Spanned::new(Chunk::Normal(names), range)];
+        let people = &[Spanned::detached(Chunk::Normal(names))];
         let people: Vec<Person> = Type::from_chunks(people).unwrap();
         assert_eq!(people.len(), 3);
 
@@ -311,8 +310,7 @@ mod tests {
 Aldus Manutius and
 Claude Garamond",
         );
-        let range = std::ops::Range { start: 0, end: names.len() };
-        let people = &[Spanned::new(Chunk::Normal(names), range)];
+        let people = &[Spanned::detached(Chunk::Normal(names))];
         let people1: Vec<Person> = Type::from_chunks(people).unwrap();
         assert_eq!(people1.len(), 3);
 
@@ -323,8 +321,7 @@ Aldus Manutius
 and
 Claude Garamond",
         );
-        let range = std::ops::Range { start: 0, end: names.len() };
-        let people = &[Spanned::new(Chunk::Normal(names), range)];
+        let people = &[Spanned::detached(Chunk::Normal(names))];
         let people2: Vec<Person> = Type::from_chunks(people).unwrap();
         assert_eq!(people2.len(), 3);
 
@@ -334,8 +331,7 @@ and
 Aldus Manutius and
 Claude Garamond",
         );
-        let range = std::ops::Range { start: 0, end: names.len() };
-        let people = &[Spanned::new(Chunk::Normal(names), range)];
+        let people = &[Spanned::detached(Chunk::Normal(names))];
         let people3: Vec<Person> = Type::from_chunks(people).unwrap();
         assert_eq!(people3.len(), 3);
 
@@ -362,8 +358,7 @@ Claude Garamond",
 Aldus Manutius and
 Claude Garamond",
         );
-        let range = std::ops::Range { start: 0, end: names.len() };
-        let people = &[Spanned::new(Chunk::Normal(names), range)];
+        let people = &[Spanned::detached(Chunk::Normal(names))];
         let people: Vec<Person> = Type::from_chunks(people).unwrap();
         assert_eq!(people.len(), 3);
 
@@ -379,8 +374,7 @@ Claude Garamond",
 Aldus Manutius and
 Claude Garamond and",
         );
-        let range = std::ops::Range { start: 0, end: names.len() };
-        let people = &[Spanned::new(Chunk::Normal(names), range)];
+        let people = &[Spanned::detached(Chunk::Normal(names))];
         let people: Vec<Person> = Type::from_chunks(people).unwrap();
         assert_eq!(people.len(), 3);
 
@@ -396,8 +390,7 @@ Claude Garamond and",
 Aldus Manutius and
 Claude Garamond",
         );
-        let range = std::ops::Range { start: 0, end: names.len() };
-        let people = &[Spanned::new(Chunk::Normal(names), range)];
+        let people = &[Spanned::detached(Chunk::Normal(names))];
         let people: Vec<Person> = Type::from_chunks(people).unwrap();
         assert_eq!(people.len(), 4);
 
@@ -410,8 +403,7 @@ Claude Garamond",
 Aldus Manutius and
 Claude Garamond",
         );
-        let range = std::ops::Range { start: 0, end: names.len() };
-        let people = &[Spanned::new(Chunk::Normal(names), range)];
+        let people = &[Spanned::detached(Chunk::Normal(names))];
         let people: Vec<Person> = Type::from_chunks(people).unwrap();
         assert_eq!(people.len(), 5);
 
@@ -428,8 +420,7 @@ Claude Garamond",
         let names = String::from(
             "Johannes anderson Gutenberg and Claudeand Garamond and Aanderson Manutius",
         );
-        let range = std::ops::Range { start: 0, end: names.len() };
-        let people = &[Spanned::new(Chunk::Normal(names), range)];
+        let people = &[Spanned::detached(Chunk::Normal(names))];
         let people: Vec<Person> = Type::from_chunks(people).unwrap();
         assert_eq!(people.len(), 3);
 

--- a/src/types/person.rs
+++ b/src/types/person.rs
@@ -390,6 +390,40 @@ Claude Garamond and",
     }
 
     #[test]
+    fn test_consecutive_and() {
+        let names = String::from(
+            "Johannes Gutenberg and and
+Aldus Manutius and
+Claude Garamond and",
+        );
+        let range = std::ops::Range { start: 0, end: names.len() };
+        let people = &[Spanned::new(Chunk::Normal(names), range)];
+        let people: Vec<Person> = Type::from_chunks(people).unwrap();
+        assert_eq!(people.len(), 4);
+
+        assert_eq!(people[1].name, "");
+        assert_eq!(people[1].prefix, "");
+        assert_eq!(people[1].given_name, "");
+
+        let names = String::from(
+            "Johannes Gutenberg and and and
+Aldus Manutius and
+Claude Garamond and",
+        );
+        let range = std::ops::Range { start: 0, end: names.len() };
+        let people = &[Spanned::new(Chunk::Normal(names), range)];
+        let people: Vec<Person> = Type::from_chunks(people).unwrap();
+        assert_eq!(people.len(), 5);
+
+        assert_eq!(people[1].name, "");
+        assert_eq!(people[1].prefix, "");
+        assert_eq!(people[1].given_name, "");
+        assert_eq!(people[2].name, "");
+        assert_eq!(people[2].prefix, "");
+        assert_eq!(people[2].given_name, "");
+    }
+
+    #[test]
     fn test_name_with_and_inside() {
         let names = String::from(
             "Johannes anderson Gutenberg and Claudeand Garamond and Aanderson Manutius",

--- a/src/types/person.rs
+++ b/src/types/person.rs
@@ -438,6 +438,19 @@ Claude Garamond",
     }
 
     #[test]
+    fn test_verbatim() {
+        let people = &[
+            Spanned::detached(Chunk::Verbatim("Johannes".to_string())),
+            Spanned::detached(Chunk::Normal(" ".to_string())),
+            Spanned::detached(Chunk::Verbatim("Gutenberg".to_string())),
+        ];
+        let people: Vec<Person> = Type::from_chunks(people).unwrap();
+        assert_eq!(people.len(), 1);
+        assert_eq!(people[0].name, "Gutenberg");
+        assert_eq!(people[0].given_name, "Johannes");
+    }
+
+    #[test]
     fn test_person_comma() {
         let p = Person::parse(&[Spanned::zero(N("jean de la fontaine,"))]);
         assert_eq!(p.name, "fontaine");

--- a/src/types/person.rs
+++ b/src/types/person.rs
@@ -390,6 +390,29 @@ Claude Garamond and",
     }
 
     #[test]
+    fn test_name_with_and_inside() {
+        let names = String::from(
+            "Johannes anderson Gutenberg and Claudeand Garamond and Aanderson Manutius",
+        );
+        let range = std::ops::Range { start: 0, end: names.len() };
+        let people = &[Spanned::new(Chunk::Normal(names), range)];
+        let people: Vec<Person> = Type::from_chunks(people).unwrap();
+        assert_eq!(people.len(), 3);
+
+        assert_eq!(people[0].name, "Gutenberg");
+        assert_eq!(people[0].prefix, "anderson");
+        assert_eq!(people[0].given_name, "Johannes");
+
+        assert_eq!(people[1].name, "Garamond");
+        assert_eq!(people[1].prefix, "");
+        assert_eq!(people[1].given_name, "Claudeand");
+
+        assert_eq!(people[2].name, "Manutius");
+        assert_eq!(people[2].prefix, "");
+        assert_eq!(people[2].given_name, "Aanderson");
+    }
+
+    #[test]
     fn test_person_comma() {
         let p = Person::parse(&[Spanned::zero(N("jean de la fontaine,"))]);
         assert_eq!(p.name, "fontaine");

--- a/src/types/person.rs
+++ b/src/types/person.rs
@@ -448,6 +448,35 @@ Claude Garamond",
         assert_eq!(people.len(), 1);
         assert_eq!(people[0].name, "Gutenberg");
         assert_eq!(people[0].given_name, "Johannes");
+
+        let people = &[
+            Spanned::detached(Chunk::Verbatim("Johannes".to_string())),
+            Spanned::detached(Chunk::Normal(" ".to_string())),
+            Spanned::detached(Chunk::Verbatim("Gutenberg".to_string())),
+            Spanned::detached(Chunk::Normal(" and ".to_string())),
+            Spanned::detached(Chunk::Verbatim("Manutius".to_string())),
+            Spanned::detached(Chunk::Normal(" ".to_string())),
+            Spanned::detached(Chunk::Verbatim("Aldus".to_string())),
+        ];
+        let people: Vec<Person> = Type::from_chunks(people).unwrap();
+        assert_eq!(people.len(), 2);
+        assert_eq!(people[0].name, "Gutenberg");
+        assert_eq!(people[0].given_name, "Johannes");
+        assert_eq!(people[1].name, "Aldus");
+        assert_eq!(people[1].given_name, "Manutius");
+
+        let people = &[
+            Spanned::detached(Chunk::Verbatim("Johannes".to_string())),
+            Spanned::detached(Chunk::Normal(" ".to_string())),
+            Spanned::detached(Chunk::Verbatim("Gutenberg".to_string())),
+            Spanned::detached(Chunk::Normal(" and Manutius Aldus".to_string())),
+        ];
+        let people: Vec<Person> = Type::from_chunks(people).unwrap();
+        assert_eq!(people.len(), 2);
+        assert_eq!(people[0].name, "Gutenberg");
+        assert_eq!(people[0].given_name, "Johannes");
+        assert_eq!(people[1].name, "Aldus");
+        assert_eq!(people[1].given_name, "Manutius");
     }
 
     #[test]

--- a/src/types/person.rs
+++ b/src/types/person.rs
@@ -16,7 +16,7 @@ pub struct Person {
     /// The prefix is placed between given name and name. It could, for example,
     /// be a nobiliary particle.
     pub prefix: String,
-    /// The suffix is placed after the name (e.g. "Jr.").
+    /// The suffix is placed after the name (e.g., "Jr.").
     pub suffix: String,
 }
 
@@ -56,9 +56,9 @@ impl Person {
     /// form `<First> <Prefix> <Last>`.
     fn parse_unified(chunks: ChunksRef) -> Self {
         // Find end of first sequence of capitalized words (denominated by first
-        // lowercase word), start of last capitalized seqence.
+        // lowercase word), start of last capitalized sequence.
         // If there is no subsequent capitalized word, take last one.
-        // Treat verbatim as capital letters
+        // Treat verbatim as capital letters.
         let mut word_start = true;
         let mut capital = false;
         let mut seen_lowercase = false;


### PR DESCRIPTION
## Related Issue

Try to fix #28.

## What are the changes/fixes in this PR?

This PR adds support for multiline author field.

In p. 16 of the BibLaTeX manual, it states that:

> Name lists are parsed and split up into the individual items at the `and` delimiter.

However, the old implementation assumes that only `<space>and<space>` is valid, which causes the problem in the reference issue. The correct approach is that we consider a split valid only if the character before `and` and the next character after `and` are whitespace (either ASCII or Unicode whitespace is a valid option).

### Leading or Trailing "and"

When "and" is encountered at the beginning or end of a person's name, and there are no other possible splits (no surrounding whitespaces), it should be considered as part of the name.

### Consecutive "and"

When there are multiple consecutive "and" separated by spaces, we should treat the name between the two "and" as empty.

### Experiment

I tried to test the above claim in latex with the following files, using the bib style file downloaded from [here](https://www.bibtex.com/s/bibliography-style-ieeetran-ieeetran/):

```tex
\documentclass[a4paper,10pt]{article}

\begin{document}

\cite{gamma1995design}

\cite{linebreak}

\cite{leadingand}

\cite{trailingand}

\cite{middleand}

\cite{andand}

\cite{andandand}

\bibliographystyle{IEEEtran}
\bibliography{cite}
\end{document}
```

```bib
@book{gamma1995design,
  title     = {Design patterns: elements of reusable object-oriented software},
  author    = {Gamma, Erich and Helm, Richard and Johnson, Ralph and Vlissides, John M.},
  year      = {1995},
}

@book{linebreak,
  title     = {Design patterns: elements of reusable object-oriented software},
  author    = {Gamma, Erich
               and
               Helm, Richard and
               Johnson, Ralph},
  year      = {1995},
}

@book{leadingand,
  title     = {Design patterns: elements of reusable object-oriented software},
  author    = {and Gamma, Erich and Helm, Richard and Johnson, Ralph and Vlissides, John M.},
  year      = {1995},
}

@book{trailingand,
  title     = {Design patterns: elements of reusable object-oriented software},
  author    = {Gamma, Erich and Helm, Richard and Johnson, Ralph and Vlissides, John M. and},
  year      = {1995},
}

@book{middleand,
  title     = {Design patterns: elements of reusable object-oriented software},
  author    = {Gamma, Erich and Hello and Helm, Richard and Johnson, Ralph and Vlissides, John M.},
  year      = {1995},
}

@book{andand,
  title     = {Design patterns: elements of reusable object-oriented software},
  author    = {Gamma, Erich and and Helm, Richard and Johnson, Ralph and Vlissides, John M.},
  year      = {1995},
}

@book{andandand,
  title     = {Design patterns: elements of reusable object-oriented software},
  author    = {Gamma, Erich and and and Helm, Richard and Johnson, Ralph and Vlissides, John M.},
  year      = {1995},
}
```

I get the following outputs:

<img width="694" alt="image" src="https://github.com/typst/biblatex/assets/45459572/35b3e5b3-8c62-415e-922b-7e9392110e0c">

- It is clear that the multi-line author field is supported (from 2).
- The leading "and" is seen as part of the first person's name (from 3).
- The trailing "and" is seen as part of the last person's name (from 4).
- When there are multiple consecutive "and", some authors have empty names.