### PR TITLE
make keys case insensitive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ impl Bibliography {
             let mut fields: BTreeMap<String, Vec<Spanned<Chunk>>> = BTreeMap::new();
             for spanned_field in entry.v.fields.into_iter() {
                 let (field_key, field_value) = spanned_field;
-                let field_key = field_key.v.to_string();
+                let field_key = field_key.v.to_string().to_ascii_lowercase();
                 let parsed = resolve::parse_field(&field_key, &field_value.v, abbr)?;
                 fields.insert(field_key, parsed);
             }
@@ -1174,5 +1174,22 @@ mod tests {
         e.set_author(brian.clone());
 
         assert_eq!(Ok(brian), e.author());
+    }
+
+    #[test]
+    fn test_case_sensitivity() {
+        let contents = fs::read_to_string("tests/case.bib").unwrap();
+        let bibliography = Bibliography::parse(&contents).unwrap();
+
+        let entry = bibliography.get("biblatex2023").unwrap();
+        let author = entry.author();
+
+        match author {
+            Ok(a) => assert_eq!(a[0].name, "Kime"),
+            Err(RetrievalError::Missing(_)) => {
+                panic!("Tags should be case insensitive.");
+            }
+            _ => panic!(),
+        }
     }
 }

--- a/tests/case.bib
+++ b/tests/case.bib
@@ -1,0 +1,8 @@
+@mAnual{biblatex2023,
+  AUTHOR={Kime, Phillip and Wemheuer, Moritz and Lehman, Phillip},
+  tItle={The biblatex Package},
+  dAte={2023-05-03},
+  sUbtitle={Programmable Bibliographies and Citations},
+  versiOn={3.19},
+  url={https://mirrors.rit.edu/CTAN/macros/latex/contrib/biblatex/doc/biblatex.pdf}
+}


### PR DESCRIPTION
Some BibTeX citation generators on some publishers' cites generate capitalized keys, e.g.

```bibtex
@manual{biblatex2023,
  AUTHOR={Kime, Phillip and Wemheuer, Moritz and Lehman, Phillip},
  TITLE={The biblatex Package},
  DATE={2023-05-03},
  SUBTITLE={Programmable Bibliographies and Citations},
  VERSION={3.19},
  URL={https://mirrors.rit.edu/CTAN/macros/latex/contrib/biblatex/doc/biblatex.pdf}
}
```

The [BibLaTeX manual](https://mirrors.rit.edu/CTAN/macros/latex/contrib/biblatex/doc/biblatex.pdf#section.2) specifies that keys in `*.bib` files can be in any case, just that within LaTeX, they are retrieved in lowercase. And, BibLaTeX still retrieves the correct data. This PR makes them insensitive here too.