### PR TITLE
Fix dollar sign parsing in URLs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1173,7 +1173,12 @@ Martin}}"#;
         assert_eq!(
             e.to_biblatex_string(),
             "@online{finextraFedGovernorChallenges2019,\nauthor = {FinExtra},\ndate = {2019-12-18},\nfile = {C:\\\\Users\\\\mhaug\\\\Zotero\\\\storage\\\\VY9LAKFE\\\\fed-governor-challenges-facebooks-libra-project.html},\ntitle = {Fed {Governor} Challenges {Facebook}'s {Libra} Project},\nurl = {https://www.finextra.com/newsarticle/34986/fed-governor-challenges-facebooks-libra-project},\nurldate = {2020-08-22},\n}"
-        )
+        );
+
+        // Test URLs with math and backslashes
+        let e = bibliography.get("weirdUrl2023").unwrap();
+        assert_eq!(e.url().unwrap(), r#"example.com?A=$B\%\{}"#);
+        assert_eq!(e.doi().unwrap(), r#"example.com?A=$B\%\{}"#);
     }
 
     #[test]

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -87,7 +87,7 @@ impl<'s> ContentParser<'s> {
                     let sequence = self.backslash()?;
                     self.current_chunk.get_mut().push_str(&sequence)
                 }
-                '$' => {
+                '$' if !self.verb_field => {
                     self.turnaround(depth);
                     let math = self.math()?;
                     self.result.push(math);

--- a/tests/libra.bib
+++ b/tests/libra.bib
@@ -442,3 +442,15 @@
   file = {C\:\\Users\\mhaug\\Zotero\\storage\\HGBKSYXN\\facebook-libra-partly-created-by-female-engineer-morgan-beller.html},
   langid = {english}
 }
+
+@article{weirdUrl2023,
+  author = {W. Url},
+  journal = {Journal},
+  number  = {1},
+  title = {Title},
+  volume = {2},
+  year = {2023},
+  comment = {3\$},
+  url = {example.com?A=$B\%\\\{\}},
+  doi = {example.com?A=$B\%\\\{\}},
+}


### PR DESCRIPTION
Fixes #53

Note that, with existing code, backslashes are usually printed verbatim, _except_ when they precede another backslash or `{}`. I wonder if we could want to make them _always_ verbatim, but not sure what would be consistent with BibTeX itself.