### PR TITLE
Add `std::error::Error` impls for error types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,8 @@ impl Display for RetrievalError {
     }
 }
 
+impl std::error::Error for RetrievalError {}
+
 impl From<TypeError> for RetrievalError {
     fn from(err: TypeError) -> Self {
         Self::TypeError(err)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,14 @@ impl Display for RetrievalError {
     }
 }
 
-impl std::error::Error for RetrievalError {}
+impl std::error::Error for RetrievalError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Missing(_) => None,
+            Self::TypeError(err) => Some(err),
+        }
+    }
+}
 
 impl From<TypeError> for RetrievalError {
     fn from(err: TypeError) -> Self {

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -75,6 +75,8 @@ impl fmt::Display for ParseError {
     }
 }
 
+impl std::error::Error for ParseError {}
+
 /// Error conditions that might occur during initial parsing of the
 /// bibliography.
 ///

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -43,6 +43,8 @@ impl fmt::Display for TypeError {
     }
 }
 
+impl std::error::Error for TypeError {}
+
 /// Error conditions that might occur while parsing the chunks in a field into a specific
 /// [`Type`].
 ///


### PR DESCRIPTION
The trait is meant for error types. This also makes it more convenient for users wrapping `biblatex`'s error types into their own errors and using the `thiserror` crate to derive error traits.