### PR TITLE
Bump strum to v0.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = ["bench"]
 [dependencies]
 numerals = "0.1"
 paste = "1"
-strum = { version = "0.26", features = ["derive"] }
+strum = { version = "0.27", features = ["derive"] }
 unicode-normalization = "0.1"
 serde = { version = "1", features = ["derive"], optional = true }
 unscanny = "0.1"


### PR DESCRIPTION
This is a breaking change in the strum public API. Changed items in the public API for v0.27:
```diff
-pub fn strum::EnumProperty::get_int(&self, _prop: &str) -> core::option::Option<usize>
+pub fn strum::EnumProperty::get_int(&self, _prop: &str) -> core::option::Option<i64>
```
`get_int` is not used in `biblatex`.  Proposing this change, since I am getting a strum version mismatch, when compiling a project that depends on biblatex, and also depends on the updated version of strum .

Taking a look to `typst` deps tree, `strum` is only used in biblatex, via `hayagriva` via `typst-library`, so no impact is expected in typst.
