### PR TITLE
Fix range parsing

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -492,8 +492,9 @@ mod tests {
         assert_eq!(res[1], 37..39);
     }
 
+    // Hayagriva issue #340
     #[test]
-    fn test_hayagriva_issue_340() {
+    fn test_non_numeric_page_ranges() {
         let bib = Bibliography::parse(
             r#"@inproceedings{test,
           author = {John Doe},
@@ -507,6 +508,32 @@ mod tests {
         let t = bib.get("test").unwrap();
         let pages = t.get("pages").unwrap();
         let parsed: PermissiveType<std::ops::Range<u32>> = pages.parse().unwrap();
-        assert!(matches!(parsed, PermissiveType::Chunks(_)))
+        let PermissiveType::Chunks(chunks) = parsed else {
+            panic!("Expected chunks");
+        };
+        let parsed_chunks: String = chunk_chars(&chunks).map(|(c, _)| c).collect();
+        assert_eq!(parsed_chunks, "1A1");
+    }
+
+    #[test]
+    fn test_non_numeric_page_ranges_2() {
+        let bib = Bibliography::parse(
+            r#"@inproceedings{test,
+            author = {John Doe},
+            title = {Interesting Findings},
+            journal = {Example Journal},
+            year = {2024},
+            pages = {hello world! this is a page!}
+        }"#,
+        )
+        .unwrap();
+        let t = bib.get("test").unwrap();
+        let pages = t.get("pages").unwrap();
+        let parsed: PermissiveType<std::ops::Range<u32>> = pages.parse().unwrap();
+        let PermissiveType::Chunks(chunks) = parsed else {
+            panic!("Expected chunks");
+        };
+        let parsed_chunks: String = chunk_chars(&chunks).map(|(c, _)| c).collect();
+        assert_eq!(parsed_chunks, "hello world! this is a page!");
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -477,7 +477,7 @@ mod tests {
 
     #[test]
     fn test_ranges() {
-        let ranges = &[Spanned::zero(N("31--43,21:4-21:6,  194 --- 245"))];
+        let ranges = &[Spanned::zero(N("31--43,4-6,  194 --- 245"))];
         let res = ranges.parse::<Vec<Range<u32>>>().unwrap();
         assert_eq!(res[0], 31..43);
         assert_eq!(res[1], 4..6);

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -506,7 +506,7 @@ mod tests {
         .unwrap();
         let t = bib.get("test").unwrap();
         let pages = t.get("pages").unwrap();
-        let parsed: PermissiveType<std::ops::Range<u32>> = pages.parse().unwrap();`
+        let parsed: PermissiveType<std::ops::Range<u32>> = pages.parse().unwrap();
         assert!(matches!(parsed, PermissiveType::Chunks(_)))
     }
 }


### PR DESCRIPTION
Fixes typst/hayagriva#340.

One test fails. Someone needs to explain to me why `21:4-21:6` should be parsed as the range `4..6`. That loses information and makes no sense to me.