### PR TITLE
Fix AuthorMode of InProceedings

### DIFF
--- a/src/mechanics.rs
+++ b/src/mechanics.rs
@@ -398,7 +398,7 @@ impl EntryType {
                 reqs.forbidden.push("pagetotal");
 
                 reqs.page_chapter_field = PagesChapterMode::BothOptional;
-                reqs.author_eds_field = AuthorMode::BothRequired;
+                reqs.author_eds_field = AuthorMode::AuthorRequiredEditorOptional;
             }
             Self::Manual => {
                 reqs.optional.push("edition");


### PR DESCRIPTION
Fix inproceedings entry requirements: changed author_eds_field from BothRequired to AuthorRequiredEditorOptional, since according to the BibLaTeX documentation the editor field is optional.

<img width="2238" height="768" alt="image" src="https://github.com/user-attachments/assets/861186dd-38bf-4897-96d8-0364803690f3" />
