### PR TITLE
chore: replace paste by pastey

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = ["bench"]
 
 [dependencies]
 roman-numerals-rs = "3.1.0"
-paste = "1"
+pastey = "0.2.1"
 strum = { version = "0.27", features = ["derive"] }
 unicode-normalization = "0.1"
 serde = { version = "1", features = ["derive"], optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ use std::fmt::{Debug, Display, Formatter, Write};
 use macros::*;
 use mechanics::{is_verbatim_field, AuthorMode, PagesChapterMode};
 
-use paste::paste;
+use pastey::paste;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
paste crate is no longer maintained:
https://rustsec.org/advisories/RUSTSEC-2024-0436,
we can replace it with pastey