### PR TITLE
Use HashMap to resolve abbreviations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub use raw::{
 };
 pub use types::*;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter, Write};
 
@@ -126,7 +126,8 @@ impl Bibliography {
     /// `crossref` links resolved.
     pub fn from_raw(raw: RawBibliography) -> Result<Self, ParseError> {
         let mut res = Self::new();
-        let abbr = &raw.abbreviations;
+        let abbr: HashMap<&str, &_> =
+            raw.abbreviations.iter().map(|p| (p.key.v, &p.value.v)).collect();
 
         for entry in raw.entries {
             // Check that the key is not repeated
@@ -141,7 +142,7 @@ impl Bibliography {
             for spanned_field in entry.v.fields.into_iter() {
                 let field_key = spanned_field.key.v.to_string().to_ascii_lowercase();
                 let parsed =
-                    resolve::parse_field(&field_key, &spanned_field.value.v, abbr)?;
+                    resolve::parse_field(&field_key, &spanned_field.value.v, &abbr)?;
                 fields.insert(field_key, parsed);
             }
             res.insert(Entry {

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1,10 +1,10 @@
+use std::collections::HashMap;
+
 use unicode_normalization::char;
 
 use crate::chunk::{Chunk, Chunks};
 use crate::mechanics::is_verbatim_field;
-use crate::raw::{
-    is_id_continue, Field, Pair, ParseError, ParseErrorKind, RawChunk, Token,
-};
+use crate::raw::{is_id_continue, Field, ParseError, ParseErrorKind, RawChunk, Token};
 use crate::types::get_month_for_abbr;
 use crate::{ChunksExt, Span, Spanned};
 use unscanny::Scanner;
@@ -13,7 +13,7 @@ use unscanny::Scanner;
 pub fn parse_field(
     key: &str,
     field: &Field,
-    abbreviations: &Vec<Pair<'_>>,
+    abbreviations: &HashMap<&str, &Field<'_>>,
 ) -> Result<Chunks, ParseError> {
     let mut chunks = vec![];
     for e in field {
@@ -280,16 +280,11 @@ fn resolve_abbreviation(
     key: &str,
     abbr: &str,
     span: Span,
-    map: &Vec<Pair<'_>>,
+    map: &HashMap<&str, &Field<'_>>,
 ) -> Result<Chunks, ParseError> {
-    let fields =
-        map.iter()
-            .find(|e| e.key.v == abbr)
-            .map(|e| &e.value.v)
-            .ok_or(ParseError::new(
-                span.clone(),
-                ParseErrorKind::UnknownAbbreviation(abbr.into()),
-            ));
+    let fields = map.get(abbr).copied().ok_or_else(|| {
+        ParseError::new(span.clone(), ParseErrorKind::UnknownAbbreviation(abbr.into()))
+    });
 
     if fields.is_err() {
         if let Some(month) = get_month_for_abbr(abbr) {
@@ -495,9 +490,11 @@ fn is_single_char_func(c: char, ws: bool) -> bool {
 #[cfg(test)]
 #[allow(non_snake_case)]
 mod tests {
+    use std::collections::HashMap;
+
     use crate::raw::Pair;
 
-    use super::{parse_field, Chunk, RawChunk, Spanned};
+    use super::{parse_field, Chunk, Field, RawChunk, Spanned};
 
     fn N(s: &str) -> Chunk {
         Chunk::Normal(s.to_string())
@@ -513,9 +510,13 @@ mod tests {
         Spanned::new(c, 0..0)
     }
 
+    fn pairs_to_map<'a>(pairs: &'a [Pair<'a>]) -> HashMap<&'a str, &'a Field<'a>> {
+        pairs.iter().map(|p| (p.key.v, &p.value.v)).collect()
+    }
+
     #[test]
     fn test_process() {
-        let map: Vec<_> = [("abc", "ABC"), ("hi", "hello"), ("you", "person")]
+        let pairs: Vec<_> = [("abc", "ABC"), ("hi", "hello"), ("you", "person")]
             .into_iter()
             .map(|(k, v)| {
                 Pair::new(
@@ -524,6 +525,7 @@ mod tests {
                 )
             })
             .collect();
+        let map = pairs_to_map(&pairs);
 
         let field = vec![
             z(RawChunk::Abbreviation("abc")),
@@ -546,7 +548,7 @@ mod tests {
             "\\\"{A}ther und {\"\\LaTeX \"} {\\relax for you\\}}",
         ))];
 
-        let res = parse_field("", &field, &Vec::new()).unwrap();
+        let res = parse_field("", &field, &HashMap::new()).unwrap();
         assert_eq!(res[0].v, N("Äther und "));
         assert_eq!(res[1].v, V("\"LaTeX\""));
         assert_eq!(res[2].v, N(" "));
@@ -555,17 +557,17 @@ mod tests {
 
         let field = vec![z(RawChunk::Normal("M\\\"etal S\\= ound"))];
 
-        let res = parse_field("", &field, &Vec::new()).unwrap();
+        let res = parse_field("", &field, &HashMap::new()).unwrap();
         assert_eq!(res[0].v, N("Mëtal Sōund"));
 
         let field = vec![z(RawChunk::Normal(r"L\^{e} D\~{u}ng Tr\'{a}ng"))];
 
-        let res = parse_field("", &field, &Vec::new()).unwrap();
+        let res = parse_field("", &field, &HashMap::new()).unwrap();
         assert_eq!(res[0].v, N("Lê Dũng Tráng"));
 
         let field = vec![z(RawChunk::Normal(r"\b b \c c \d a \H o \k a \r a \u a \v a"))];
 
-        let res = parse_field("", &field, &Vec::new()).unwrap();
+        let res = parse_field("", &field, &HashMap::new()).unwrap();
         assert_eq!(res[0].v, N("b̲ ç ạ ő ą å ă ǎ"));
     }
 
@@ -575,7 +577,7 @@ mod tests {
             "The $11^{th}$ International Conference on How To Make \\$\\$",
         ))];
 
-        let res = parse_field("", &field, &Vec::new()).unwrap();
+        let res = parse_field("", &field, &HashMap::new()).unwrap();
         assert_eq!(res[0].v, N("The "));
         assert_eq!(res[1].v, M("11^{th}"));
         assert_eq!(res[2].v, N(" International Conference on How To Make $$"));
@@ -587,7 +589,7 @@ mod tests {
         let field =
             vec![z(RawChunk::Normal("Bose\\textendash{}Einstein uses Win\\-dows"))];
 
-        let res = parse_field("", &field, &Vec::new()).unwrap();
+        let res = parse_field("", &field, &HashMap::new()).unwrap();
         assert_eq!(res[0].v, N("Bose–Einstein uses Windows"));
     }
 
@@ -596,7 +598,7 @@ mod tests {
         let field =
             vec![z(RawChunk::Normal("- Knitting A--Z --- A practical guide -----"))];
 
-        let res = parse_field("", &field, &Vec::new()).unwrap();
+        let res = parse_field("", &field, &HashMap::new()).unwrap();
         assert_eq!(res[0].v, N("- Knitting A–Z — A practical guide —–"));
     }
 }


### PR DESCRIPTION
Currently, the `resolve_abbreviation` function searches the abbreviations as a vector of tuples with a linear scan. When the bibliography is abbreviations-heavy, for example when using CryptoBib (https://cryptobib.di.ens.fr), this significantly slows down processing. By building a `HashMap` of abbreviations once in `from_raw`, compilation time dropped from 2.6s to 1.0s for a sample document citing one article from CryptoBib.

## Benchmarks
### Cryptobib
I get the following benchmark results using the `release` profile on an M4 MacBook Pro results for 
- The `main` branch
- An alternative branch where I used a `BTreeMap` instead of a hashmap (`btree`).
- This PR (`dict`)

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `./target/release/typst compile ../cryptobib/cryptobib.typ (branch = main)` | 2.567 ± 0.005 | 2.561 | 2.578 | 2.69 ± 0.02 |
| `./target/release/typst compile ../cryptobib/cryptobib.typ (branch = btree)` | 0.974 ± 0.007 | 0.959 | 0.983 | 1.02 ± 0.01 |
| `./target/release/typst compile ../cryptobib/cryptobib.typ (branch = dict)` | 0.955 ± 0.008 | 0.946 | 0.967 | 1.00 |


Here I compiled the following document `cryptobib.typ` using cryptobib
```typst
Public-key cryptography was first introduced by @DifHel76.

#bibliography("cryptobib.bib")
```
where `cryptobib.bib` is the concatination of `crypto.bib` and `abbrev3.bib` from https://cryptobib.di.ens.fr.

### Small bibliography
While using a `HashMap` for abbreviations can significantly improve performance for large bibliographies, there is a small, but consistent overhead of about 1 ms on my machine for building the HashMap when I compiled under  the `dev-fast` profile . This might be measurement error, the overhead seems to disappear with the `release` profile.
| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `./target/release/typst compile ../cryptobib/small.typ (branch = main)` | 123.6 ± 1.3 | 121.3 | 125.8 | 1.00 ± 0.02 |
| `./target/release/typst compile ../cryptobib/small.typ (branch = btree)` | 124.4 ± 3.1 | 122.1 | 135.8 | 1.01 ± 0.03 |
| `./target/release/typst compile ../cryptobib/small.typ (branch = dict)` | 123.2 ± 2.1 | 121.1 | 131.0 | 1.00 |
