### PR TITLE
Keep irregular `year`s as literal dates

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -67,11 +67,28 @@ macro_rules! date_fields {
                         .map(|d| PermissiveType::Typed(d))
                         .or_else(|_| Ok::<_, RetrievalError>(PermissiveType::Chunks(chunks.to_vec())))
                 } else {
-                    Ok(PermissiveType::Typed(Date::parse_three_fields(
-                        self.get(concat!($prefix, "year")).ok_or_else(|| RetrievalError::Missing("year".to_string()))?,
-                        self.get(concat!($prefix, "month")),
-                        self.get(concat!($prefix, "day")),
-                    )?))
+                    let year = self.get(concat!($prefix, "year")).ok_or_else(|| RetrievalError::Missing("year".to_string()))?;
+                    let month = self.get(concat!($prefix, "month"));
+                    let day = self.get(concat!($prefix, "day"));
+
+                    let parsed = Date::parse_three_fields(year, month, day);
+                    match (parsed, year, month, day) {
+                        (Ok(date), ..) => Ok(PermissiveType::Typed(date)),
+                        // Some conventions put literal dates in the `year` field
+                        // due to biblatex intricacies. See https://github.com/typst/biblatex/issues/105
+                        // for the detail.
+                        // Therefore, if the format is invalid and only `year`
+                        // is provided, then it should be treated as literal.
+                        (
+                            Err(TypeError { kind: TypeErrorKind::InvalidFormat, .. }),
+                            year,
+                            None,
+                            None,
+                        ) => Ok(PermissiveType::Chunks(year.to_vec())),
+                        // Dates in regular formats should still be rejected if
+                        // they have errors like `MonthOutOfRange`.
+                        (Err(err), ..) => Err(err.into()),
+                    }
                 }.map_err(Into::into)
             }
 

--- a/src/types/date.rs
+++ b/src/types/date.rs
@@ -412,6 +412,9 @@ impl Date {
     }
 }
 
+/// Parse the `year` field.
+///
+/// The field is not allowed to have trailing month, day, or other contents.
 fn get_year(s: &mut Scanner) -> Result<i32, TypeError> {
     s.eat_whitespace();
     let year_idx = s.cursor();
@@ -419,7 +422,10 @@ fn get_year(s: &mut Scanner) -> Result<i32, TypeError> {
     s.eat_whitespace();
     let digits = s.eat_while(char::is_ascii_digit);
 
-    if digits.is_empty() || digits.len() > 4 {
+    if digits.is_empty() {
+        return Err(TypeError::new(year_idx..s.cursor(), TypeErrorKind::InvalidFormat));
+    }
+    if digits.len() > 4 {
         return Err(TypeError::new(
             year_idx..s.cursor(),
             TypeErrorKind::WrongNumberOfDigits,
@@ -444,6 +450,10 @@ fn get_year(s: &mut Scanner) -> Result<i32, TypeError> {
         if !positive_era {
             return Ok(-year + 1);
         }
+    }
+
+    if !s.done() {
+        return Err(TypeError::new(year_idx..s.cursor(), TypeErrorKind::InvalidFormat));
     }
 
     Ok(year)
@@ -1031,6 +1041,30 @@ mod tests {
                 time: None,
             })
         );
+
+        let year = &[s(N("29979"), 0..5)];
+        let date = Date::parse_three_fields(year, None, None);
+        assert_eq!(date.err().map(|e| e.kind), Some(TypeErrorKind::WrongNumberOfDigits));
+
+        let invalid_years = vec![
+            // These are special formats in China national standard GB/T 7714—2025.
+            // They should be rejected rather than partially parsed.
+
+            // Ancient years in the original calendar are annotated within parentheses. (§7.5.4.1)
+            s(N("1705（康熙四十四年）"), 0..28),
+            // If the publication year cannot be determined, other years may be used. (§7.5.4.3)
+            s(N("c1988"), 0..5),     // copyright year
+            s(N("1995印刷"), 0..10), // printing year
+            s(N("[1936]"), 0..6),    // estimated publication year
+            // For works published serially in the same journal, the subsequent parts may not be cited separately.
+            // Instead, the year, volume, issue, page, etc. of them can be appended after the first part. (§8.5.1.3)
+            // This is not an ideal solution, but biblatex-gb7714-2025 uses this convention.
+            s(N("2011, 33(2): 20-25; 2011, 33(3): 26-30"), 0..38),
+        ];
+        for year in invalid_years {
+            let date = Date::parse_three_fields(&[year], None, None);
+            assert_eq!(date.err().map(|e| e.kind), Some(TypeErrorKind::InvalidFormat));
+        }
     }
 
     #[test]


### PR DESCRIPTION
Resolves #105

This PR makes two major changes on parsing the `year` field:

1. Previously, texts after the year are ignored silently. This PR makes it an error.

   Example input `*.bib`: `year = {1995印刷}`

   Output of `parse_three_fields(year, month, day)`:
   - Before: `Datetime { year: 1995  }` (印刷 is ignored)
   - After: `TypeError { kind: InvalidNumber }`

2. One may prefer to put literal dates in the `year` field due to biblatex intricacies. Previously, such `year`s are treated similar to errors like `2026-07-32` (day out of range). This PR treats literal `year`s as literal dates.

   Example input `*.bib`: `year = {c1988}`

   Output of `entry.date()`:
   - Before: `Err(TypeError { kind: WrongNumberOfDigits })` (The error kind is misleading. The number of digits here is four as usual; what it actually means is that the number of digits before `c` is zero.)
   - After: `Ok(Chunks([Normal("c1988")]))`

The changes can tested with this script:

<details>
<summary>main.rs for testing</summary>

```rust
use biblatex::Bibliography;

fn main() -> Result<(), Box<dyn std::error::Error>> {
    let src = r#"
% Ancient years in the original calendar are annotated within parentheses. (§7.5.4.1)
@article{ancient, year = {1705（康熙四十四年）} }

% If the publication year cannot be determined, other years may be used. (§7.5.4.3)
% copyright year
@article{copyright, year = {c1988} }
% printing year
@article{printing, year = {1995印刷} }
% estimated publication year, used by biblatex-gb7714-2025
@article{estimated-1, year = {[1936]} }
% estimated publication year, used by gbt7714-bibtex-style
@article{estimated-2, date = {1936~}, year = {[1936]} }

% For works published serially in the same journal, the subsequent parts may not be cited separately.
% Instead, the year, volume, issue, page, etc. of them can be appended after the first part. (§8.5.1.3)
@article{multiple, year = {2011，33（2）：20--25；2011，33（3）：26--30} }
    "#;
    let bibliography = Bibliography::parse(src)?;
    for entry in bibliography.iter() {
        println!(
            r#"
entry.get("year") = {:?}
entry.get("date") = {:?}
entry.date() = {:?}"#,
            entry.get("year"),
            entry.get("date"),
            entry.date()
        );
    }

    Ok(())
}
```

</details>

The diff of its output between main (1e7136b) and this PR:

```diff
diff --git a/main.txt b/this-PR.txt
index 4edd602..84e8483 100644
--- a/main.txt
+++ b/this-PR.txt
@@ -1,23 +1,23 @@
 entry.get("year") = Some([Normal("1705（康熙四十四年）")])
 entry.get("date") = None
-entry.date() = Ok(Typed(Date { value: At(Datetime { year: 1705, month: None, day: None, time: None }), uncertain: false, approximate: false }))
+entry.date() = Ok(Chunks([Normal("1705（康熙四十四年）")]))
 
 entry.get("year") = Some([Normal("c1988")])
 entry.get("date") = None
-entry.date() = Err(TypeError(TypeError { span: 277..277, kind: WrongNumberOfDigits }))
+entry.date() = Ok(Chunks([Normal("c1988")]))
 
 entry.get("year") = Some([Normal("1995印刷")])
 entry.get("date") = None
-entry.date() = Ok(Typed(Date { value: At(Datetime { year: 1995, month: None, day: None, time: None }), uncertain: false, approximate: false }))
+entry.date() = Ok(Chunks([Normal("1995印刷")]))
 
 entry.get("year") = Some([Normal("[1936]")])
 entry.get("date") = None
-entry.date() = Err(TypeError(TypeError { span: 432..432, kind: WrongNumberOfDigits }))
+entry.date() = Ok(Chunks([Normal("[1936]")]))
 
 entry.get("year") = Some([Normal("[1936]")])
 entry.get("date") = Some([Normal("1936~")])
 entry.date() = Ok(Typed(Date { value: At(Datetime { year: 1936, month: None, day: None, time: None }), uncertain: false, approximate: true }))
 
 entry.get("year") = Some([Normal("2011，33（2）：20–25；2011，33（3）：26–30")])
 entry.get("date") = None
-entry.date() = Ok(Typed(Date { value: At(Datetime { year: 2011, month: None, day: None, time: None }), uncertain: false, approximate: false }))
+entry.date() = Ok(Chunks([Normal("2011，33（2）：20–25；2011，33（3）：26–30")]))
```

## Impact on downstream projects

Hayagriva does not support literal dates at present.
Neither `Ok(Chunks)` nor `Err` becomes hayagriva's `date` field.
However, `Err` will lead to _error: Failed to parse BibLaTeX (wrong number of digits at …)_, but `Ok(Chunk)` won't.
In other words, this PR makes typst/hayagriva more tolerant.

https://typst.app/universe/package/citegeist uses this crate to parse `*.bib`. It looks like that `citegeist` doesn't use `entry.date()`, so it won't be affected.
