### PR TITLE
Keep consecutive hyphens in verbatim fields

### DIFF
--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -12,6 +12,9 @@ pub type Chunks = Vec<Spanned<Chunk>>;
 pub type ChunksRef<'a> = &'a [Spanned<Chunk>];
 
 /// Represents one part of a field value.
+///
+/// Note that the `Verbatim` variant here is unrelated to the high-level concept
+/// of verbatim fields (e.g., `file`, `url`). Such fields are usually `Normal`.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Chunk {

--- a/src/mechanics.rs
+++ b/src/mechanics.rs
@@ -719,6 +719,8 @@ impl EntryType {
 
 /// Whether a field with this key should be parsed with commands and most
 /// escapes turned off.
+///
+/// Reference: Verbatim fields and URI fields, [2.2.1 Data Types — The `biblatex` Package (`biblatex.pdf`, v3.21, 2025-07-10) | CTAN](https://mirrors.ctan.org/macros/latex/contrib/biblatex/doc/biblatex.pdf#subsubsection.2.2.1)
 pub fn is_verbatim_field(key: &str) -> bool {
     matches!(
         key,

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -114,7 +114,7 @@ impl<'s> ContentParser<'s> {
 
                     self.s.eat();
                 }
-                '-' => {
+                '-' if !self.verb_field => {
                     let mut count = 0;
                     let hyphens = self.s.eat_while(|c| {
                         let res = c == '-' && count < 3;
@@ -600,6 +600,11 @@ mod tests {
 
         let res = parse_field("", &field, &HashMap::new()).unwrap();
         assert_eq!(res[0].v, N("- Knitting A–Z — A practical guide —–"));
+
+        let url = "https://deploy-preview-601--site.netlify.app/x--y.html";
+        let field = vec![z(RawChunk::Normal(url))];
+        let res = parse_field("url", &field, &HashMap::new()).unwrap();
+        assert_eq!(res[0].v, N(url));
     }
 
     #[test]


### PR DESCRIPTION
Resolves typst/typst#5629
(This issue was created under the typst repo, but the hayagriva yaml format was unaffcted. Therefore, it can be closed by this biblatex PR.)

`--` in `url`, `file`, and other verbatim fields should be kept as is.
However, they were interpreted as en dashes (`–`). This PR fixes that.

## Example

```bibtex
% a.bib
@misc{key,
	url = {https://deploy-preview-601--site.netlify.app/x--y.html},
}
```

```sh
$ hayagriva --version
Hayagriva CLI 0.10.1

$ hayagriva a.bib
key:
  type: misc
  url: https://xn--deploy-preview-601site-h15m.netlify.app/x%E2%80%93y.html
```

As shown above, `--` in the URL are turned into en dashes. As a result, the domain is encoded using punycode, and the path is percent-encoded.

After this PR, the resulting `url` will be the same as the `url` in `a.bib`.
