### PR TITLE
Detect circular `crossref`/`xdata` inheritance

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub use raw::{
 };
 pub use types::*;
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter, Write};
 
@@ -154,9 +154,7 @@ impl Bibliography {
 
         let mut entries = res.entries.clone();
         for entry in &mut entries {
-            entry.resolve_crossrefs(&res).map_err(|e| {
-                ParseError::new(e.span, ParseErrorKind::ResolutionError(e.kind))
-            })?;
+            entry.resolve_crossrefs(&res, &mut HashSet::new())?;
         }
         res.entries = entries;
 
@@ -597,22 +595,61 @@ impl Entry {
     }
 
     /// Resolves all data dependencies defined by `crossref` and `xdata` fields.
-    fn resolve_crossrefs(&mut self, bib: &Bibliography) -> Result<(), TypeError> {
+    fn resolve_crossrefs(
+        &mut self,
+        bib: &Bibliography,
+        ancestors: &mut HashSet<String>,
+    ) -> Result<(), ParseError> {
+        ancestors.insert(self.key.clone());
+
+        let result = self.resolve_crossrefs_inner(bib, ancestors);
+
+        ancestors.remove(&self.key);
+        result
+    }
+
+    fn resolve_crossrefs_inner(
+        &mut self,
+        bib: &Bibliography,
+        ancestors: &mut HashSet<String>,
+    ) -> Result<(), ParseError> {
         let mut refs = vec![];
 
-        if let Some(crossref) = convert_result(self.get_as::<String>("crossref"))? {
-            refs.extend(bib.get(&crossref).cloned());
-        }
-
-        if let Some(keys) = convert_result(self.get_as::<Vec<String>>("xdata"))? {
-            for key in keys {
-                refs.extend(bib.get(&key).cloned());
+        if let Some(crossref) = convert_result(self.get_as::<String>("crossref"))
+            .map_err(|e| {
+                ParseError::new(e.span, ParseErrorKind::ResolutionError(e.kind))
+            })?
+        {
+            if let Some(entry) = bib.get(&crossref).cloned() {
+                refs.push((entry, self.get("crossref").unwrap().span()));
             }
         }
 
-        for mut crossref in refs {
-            crossref.resolve_crossrefs(bib)?;
-            self.resolve_single_crossref(crossref)?;
+        if let Some(keys) =
+            convert_result(self.get_as::<Vec<String>>("xdata")).map_err(|e| {
+                ParseError::new(e.span, ParseErrorKind::ResolutionError(e.kind))
+            })?
+        {
+            let span = self.get("xdata").unwrap().span();
+            for key in keys {
+                if let Some(entry) = bib.get(&key).cloned() {
+                    refs.push((entry, span.clone()));
+                }
+            }
+        }
+
+        for (mut crossref, span) in refs {
+            if ancestors.contains(&crossref.key) {
+                return Err(ParseError::new(
+                    span,
+                    ParseErrorKind::CircularReference(crossref.key),
+                ));
+            }
+
+            crossref.resolve_crossrefs(bib, ancestors)?;
+            self.resolve_single_crossref(crossref).map_err(|e| {
+                ParseError::new(e.span, ParseErrorKind::ResolutionError(e.kind))
+            })?;
         }
 
         self.remove("xdata");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -600,6 +600,10 @@ impl Entry {
         bib: &Bibliography,
         ancestors: &mut HashSet<String>,
     ) -> Result<(), ParseError> {
+        if self.get("crossref").is_none() && self.get("xdata").is_none() {
+            return Ok(());
+        }
+
         ancestors.insert(self.key.clone());
 
         let result = self.resolve_crossrefs_inner(bib, ancestors);

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -96,6 +96,8 @@ pub enum ParseErrorKind {
     MalformedCommand,
     /// A duplicate citation key was found.
     DuplicateKey(String),
+    /// A `crossref` or `xdata` field refers back to an entry already being resolved.
+    CircularReference(String),
     /// A type error occurred while trying to resolve cross-references.
     ResolutionError(TypeErrorKind),
 }
@@ -129,6 +131,7 @@ impl fmt::Display for ParseErrorKind {
             Self::UnknownAbbreviation(s) => write!(f, "unknown abbreviation {:?}", s),
             Self::MalformedCommand => write!(f, "malformed command"),
             Self::DuplicateKey(s) => write!(f, "duplicate key {:?}", s),
+            Self::CircularReference(s) => write!(f, "circular reference to {:?}", s),
             Self::ResolutionError(e) => {
                 write!(f, "type error occurred during crossref resolution: {}", e)
             }

--- a/tests/invalid.rs
+++ b/tests/invalid.rs
@@ -18,6 +18,29 @@ fn test_repeated_key() {
 }
 
 #[test]
+fn test_self_referential_crossref() {
+    let contents = "@incollection{Hartman2022, crossref = {Hartman2022}}";
+
+    assert_eq!(
+        Bibliography::parse(contents).unwrap_err().kind,
+        ParseErrorKind::CircularReference("Hartman2022".into()),
+    );
+}
+
+#[test]
+fn test_indirect_crossref_cycle() {
+    let contents = r#"
+        @incollection{a, crossref = {b}}
+        @collection{b, crossref = {a}}
+    "#;
+
+    assert_eq!(
+        Bibliography::parse(contents).unwrap_err().kind,
+        ParseErrorKind::CircularReference("a".into()),
+    );
+}
+
+#[test]
 fn test_parse_incorrect_result() {
     let contents = fs::read_to_string("tests/fixtures/invalid/incorrect_syntax.bib")
         .unwrap()


### PR DESCRIPTION
Fixes #92.

The change helps to detect circular `crossref` and `xdata` inheritance, it also returns a parse error instead of recursing until a stack overflow.

On tests, I added tests covering in/direct cycles.