### PR TITLE
Don't escape math on serialization

### DIFF
--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -65,6 +65,10 @@ impl Chunk {
     /// The `is_verbatim` argument indicates whether this string is intended for
     /// a verbatim field like `file` with limited escapes.
     pub fn to_biblatex_string(&self, is_verbatim: bool) -> String {
+        if let Chunk::Math(s) = self {
+            return s.clone();
+        }
+
         let mut s = String::new();
         for c in self.get().chars() {
             if is_escapable(c, is_verbatim, false) {

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -65,6 +65,7 @@ impl Chunk {
     /// The `is_verbatim` argument indicates whether this string is intended for
     /// a verbatim field like `file` with limited escapes.
     pub fn to_biblatex_string(&self, is_verbatim: bool) -> String {
+        // Ref.: https://github.com/typst/biblatex/issues/76.
         if let Chunk::Math(s) = self {
             return s.clone();
         }

--- a/tests/valid.rs
+++ b/tests/valid.rs
@@ -83,6 +83,23 @@ fn test_bibtex_conversion() {
 }
 
 #[test]
+fn test_biblatex_serialization_math_not_escaped() {
+    let contents = r#"
+        @article{key,
+          title = {Explicit homotopy limits of $\mathrm{dg}$-categories and twisted complexes},
+        }
+    "#;
+
+    let bibliography = Bibliography::parse(contents).unwrap();
+    let entry = bibliography.get("key").unwrap();
+
+    assert_eq!(
+        entry.to_biblatex_string(),
+        "@article{key,\ntitle = {Explicit homotopy limits of $\\mathrm{dg}$-categories and twisted complexes},\n}"
+    );
+}
+
+#[test]
 fn test_verify() {
     let mut contents = fs::read_to_string("tests/fixtures/valid/gral.bib").unwrap();
     let mut bibliography = Bibliography::parse(&contents).unwrap();

--- a/tests/valid.rs
+++ b/tests/valid.rs
@@ -100,6 +100,23 @@ fn test_biblatex_serialization_math_not_escaped() {
 }
 
 #[test]
+fn test_biblatex_serialization_accent_decoded_to_unicode() {
+    let contents = r#"
+        @article{key,
+          subtitle = {Hyper-K\"ahler Fourfolds Fibered by Elliptic Products},
+        }
+    "#;
+
+    let bibliography = Bibliography::parse(contents).unwrap();
+    let entry = bibliography.get("key").unwrap();
+
+    assert_eq!(
+        entry.to_biblatex_string(),
+        "@article{key,\nsubtitle = {Hyper-Kähler Fourfolds Fibered by Elliptic Products},\n}"
+    );
+}
+
+#[test]
 fn test_verify() {
     let mut contents = fs::read_to_string("tests/fixtures/valid/gral.bib").unwrap();
     let mut bibliography = Bibliography::parse(&contents).unwrap();

--- a/tests/valid.rs
+++ b/tests/valid.rs
@@ -83,6 +83,26 @@ fn test_bibtex_conversion() {
 }
 
 #[test]
+#[ignore = "control-space commands (e.g. `\\ `) are re-escaped on serialization"]
+fn test_biblatex_serialization_preserves_tex_input() {
+    let contents = r#"
+        @article{key,
+          title = {Explicit homotopy limits of $\mathrm{dg}$-categories and twisted complexes},
+          subtitle = {Hyper-K\"ahler Fourfolds Fibered by Elliptic Products},
+          institution = {Dept.\ of Computer Science, Stanford Univ.},
+        }
+    "#;
+
+    let bibliography = Bibliography::parse(contents).unwrap();
+    let entry = bibliography.get("key").unwrap();
+    entry.to_bibtex_string().unwrap();
+    assert_eq!(
+        entry.to_biblatex_string(),
+        "@article{key,\ninstitution = {Dept.\\ of Computer Science, Stanford Univ.},\nsubtitle = {Hyper-Kähler Fourfolds Fibered by Elliptic Products},\ntitle = {Explicit homotopy limits of $\\mathrm{dg}$-categories and twisted complexes},\n}"
+    );
+}
+
+#[test]
 fn test_biblatex_serialization_math_not_escaped() {
     let contents = r#"
         @article{key,
@@ -113,6 +133,24 @@ fn test_biblatex_serialization_accent_decoded_to_unicode() {
     assert_eq!(
         entry.to_biblatex_string(),
         "@article{key,\nsubtitle = {Hyper-Kähler Fourfolds Fibered by Elliptic Products},\n}"
+    );
+}
+
+#[test]
+#[ignore = "control-space commands (e.g. `\\ `) are re-escaped on serialization"]
+fn test_biblatex_serialization_control_space_preserved() {
+    let contents = r#"
+        @article{key,
+          institution = {Dept.\ of Computer Science, Stanford Univ.},
+        }
+    "#;
+
+    let bibliography = Bibliography::parse(contents).unwrap();
+    let entry = bibliography.get("key").unwrap();
+
+    assert_eq!(
+        entry.to_biblatex_string(),
+        "@article{key,\ninstitution = {Dept.\\ of Computer Science, Stanford Univ.},\n}"
     );
 }
 

--- a/tests/valid.rs
+++ b/tests/valid.rs
@@ -84,6 +84,7 @@ fn test_bibtex_conversion() {
 
 #[test]
 #[ignore = "control-space commands (e.g. `\\ `) are re-escaped on serialization"]
+/// Ref.: https://github.com/typst/biblatex/issues/76.
 fn test_biblatex_serialization_preserves_tex_input() {
     let contents = r#"
         @article{key,
@@ -103,6 +104,7 @@ fn test_biblatex_serialization_preserves_tex_input() {
 }
 
 #[test]
+/// Ref.: https://github.com/typst/biblatex/issues/76.
 fn test_biblatex_serialization_math_not_escaped() {
     let contents = r#"
         @article{key,
@@ -120,6 +122,7 @@ fn test_biblatex_serialization_math_not_escaped() {
 }
 
 #[test]
+/// Ref.: https://github.com/typst/biblatex/issues/76.
 fn test_biblatex_serialization_accent_decoded_to_unicode() {
     let contents = r#"
         @article{key,
@@ -138,6 +141,7 @@ fn test_biblatex_serialization_accent_decoded_to_unicode() {
 
 #[test]
 #[ignore = "control-space commands (e.g. `\\ `) are re-escaped on serialization"]
+/// Ref.: https://github.com/typst/biblatex/issues/76.
 fn test_biblatex_serialization_control_space_preserved() {
     let contents = r#"
         @article{key,


### PR DESCRIPTION
Related to #76, it fixes the math serialization, but the spacing one is still wrong, I added ignored tests for that case, for accents and the math. The spacing stuff I saw it a bit complex as for what correct design to come up with for the solution, so I left it.