### PR TITLE
Add tests for `@string` abbreviations

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -663,6 +663,27 @@ mod tests {
     }
 
     #[test]
+    /// Ref.: https://github.com/typst/biblatex/issues/32.
+    /// A single `@string{...}` block may define several abbreviations at
+    /// once, comma-separated, just like a regular entry's field list.
+    fn test_wide_string_syntax() {
+        let bt = RawBibliography::parse(
+            "@string{
+                anch-ie = {Angew.~Chem. Int.~Ed.},
+                cup     = {Cambridge University Press},
+                dtv     = {Deutscher Taschenbuch-Verlag}
+            }",
+        )
+        .unwrap();
+
+        assert_eq!(
+            bt.abbreviations.iter().map(|p| p.key.v).collect::<Vec<_>>(),
+            vec!["anch-ie", "cup", "dtv"]
+        );
+        assert_eq!(format(&bt.abbreviations[1].value.v), "{Cambridge University Press}");
+    }
+
+    #[test]
     fn test_escape() {
         assert_eq!(test_prop("author", "{Mister A\\}\"B\"}"), "{Mister A\\}\"B\"}");
     }

--- a/tests/valid.rs
+++ b/tests/valid.rs
@@ -25,6 +25,26 @@ fn test_and_others_name_marker() {
 }
 
 #[test]
+/// Ref.: https://github.com/typst/biblatex/issues/32.
+fn test_wide_string_syntax() {
+    let contents = r#"
+        @string{
+          jomch = {J.~Organomet. Chem.},
+          pup   = {Princeton University Press}
+        }
+        @article{aksin, journaltitle = jomch, publisher = pup, date = 2006}
+    "#;
+    let bibliography = Bibliography::parse(contents).unwrap();
+    let entry = bibliography.get("aksin").unwrap();
+
+    assert_eq!(entry.journal_title().unwrap().format_verbatim(), "J.~Organomet. Chem.");
+    assert_eq!(
+        entry.publisher().unwrap()[0].format_verbatim(),
+        "Princeton University Press"
+    );
+}
+
+#[test]
 fn test_keys() {
     let contents = fs::read_to_string("tests/fixtures/valid/editortypes.bib").unwrap();
 


### PR DESCRIPTION
Closes #32, as it's already solved but seemingly had no regression tests.